### PR TITLE
Hotfix: build.gradle 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,8 +49,8 @@ dependencies {
   testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 	//config restTemplate
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.apache.httpcomponents.client5:httpclient5:5.3.1'
+	implementation 'org.apache.httpcomponents.client5:httpclient5'
+
 }
 
 tasks.named('test') {


### PR DESCRIPTION
- build.gradle의 client5 버전 명시 제거 -> 서버 안돌아가게 만든 주범